### PR TITLE
Fix Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,14 @@ uuid = "8a7b9de3-9c00-473e-88b4-7eccd7ef2fea"
 authors = ["Micky Yun Chan <michan@redhat.com> and contributors"]
 version = "0.1.0"
 
+[deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
 [compat]
+HTTP = "0.8"
+JSON = "0.21"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
If you try to install the package:

```julia
] add https://github.com/michiboo/CDSAPI.jl
```

and load it:

```julia
using CDSAPI
```

you will get an error:

```julia
HTTP not found
```

This is because dependencies are not present in the Project.toml. Every time you use a dependency in a package, you need to add it explicitly. You can cd into the project directory and type:

```julia
julia --project
```

Then add the dependencies to the project:

```julia
] add HTTP JSON Base64
```

Finally, I've added the versions of the dependencies manually to the Project.toml.